### PR TITLE
fix tmkill

### DIFF
--- a/instantos.plugin.zsh
+++ b/instantos.plugin.zsh
@@ -1,12 +1,9 @@
 # kill all tmux sessions with no terminal emulator attached
 tmkill() {
-    LIST="$(tmux ls)"
-    TSESSIONS=""
-    while read -r line; do
-        if ! echo "$line" | grep 'attached'; then
-            tmux kill-session -t "$(echo $line | grep -oP '^\d\d?')"
-        fi
-    done <<<"$LIST"
+    for i in $(tmux ls | sed '/(attached)$/d;s/: .*$//')
+    do
+        tmux kill-session -t "$i"
+    done
 }
 
 sl() {


### PR DESCRIPTION
`tmkill` broke with sessions over 100. New version is simpler, only using a
single sed command once, which sould be better than using grep in a
loop.