### PR TITLE
consistent $zhome usage

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -26,7 +26,7 @@ install_antidote_plugins() {
     echo "loading plugin bundle"
     BUNDLEFILE="${BUNDLEFILE:-/usr/share/instantshell/bundle.txt}"
     # clone antidote if necessary and generate a static plugin file
-    zhome=${ZDOTDIR:-$HOME}
+    =${ZDOTDIR:-$HOME}
     cloneantidote() {
         if [ -e /usr/share/instantshell/antidote ]
         then
@@ -47,15 +47,15 @@ install_antidote_plugins() {
 }
 
 
-if ! [ -e .zsh_plugins.zsh ]
+if ! [ -e $zhome/.zsh_plugins.zsh ]
 then
     install_antidote_plugins
 fi
 
-source ~/.zsh_plugins.zsh
+source $zhome/.zsh_plugins.zsh
 
 export STARSHIP_CONFIG=/usr/share/instantshell/starship.toml
-eval "$(starship init zsh)"
+eval "$(starship init)"
 
 export LESS='-R --use-color -Dd+r$Du+b'
 alias ls='ls --color=auto'


### PR DESCRIPTION
sourcing from `.zsh_plugins.zsh` should use `$zhome` as some employs `$ZDOTDIR`